### PR TITLE
accept raw connection string.

### DIFF
--- a/RedisAutocomplete.Tests/RedisAutocomplete.Tests.csproj
+++ b/RedisAutocomplete.Tests/RedisAutocomplete.Tests.csproj
@@ -35,7 +35,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -61,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/RedisAutocomplete.Tests/RedisAutocompleteTests.cs
+++ b/RedisAutocomplete.Tests/RedisAutocompleteTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Configuration;
 
 namespace RedisAutocomplete.Tests
 {
@@ -18,8 +19,8 @@ namespace RedisAutocomplete.Tests
         [TestMethod]
         public void InsertValuesAndQuery()
         {
-            var autocompleter = new RedisAutoComplete<string>();/*var autocompleter = new RedisAutoComplete<string>("AlternateRedisAutocomplete");*/
-            var input = new List<string>();
+            var autocompleter = new RedisAutoComplete<string>(); /*var autocompleter = new RedisAutoComplete<string>(ConfigurationManager.ConnectionStrings["AlternateRedisAutocomplete"].ConnectionString);*/
+			var input = new List<string>();
             input.Add("foo");
             input.Add("foobar");
             input.Add("bar");
@@ -50,7 +51,7 @@ namespace RedisAutocomplete.Tests
         [TestMethod]
         public void InsertValuesAndQueryDiffConnectionString()
         {
-            var autocompleter = new RedisAutoComplete<string>("AlternateRedisAutocomplete");
+            var autocompleter = new RedisAutoComplete<string>(ConfigurationManager.ConnectionStrings["AlternateRedisAutocomplete"].ConnectionString);
             var input = new List<string>();
             input.Add("foo");
             input.Add("foobar");
@@ -68,7 +69,7 @@ namespace RedisAutocomplete.Tests
         {
             try
             {
-                var autocompleter = new RedisAutoComplete<string>("WrongConnectionString");
+                var autocompleter = new RedisAutoComplete<string>(ConfigurationManager.ConnectionStrings["WrongConnectionString"].ConnectionString);
                 Assert.Fail("Expected Exception not thrown");
             }
             catch (Exception ex)

--- a/RedisAutocomplete.Tests/packages.config
+++ b/RedisAutocomplete.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
+</packages>

--- a/RedisAutocomplete/RedisAutocompleteManager.cs
+++ b/RedisAutocomplete/RedisAutocompleteManager.cs
@@ -23,9 +23,8 @@ namespace RedisAutocomplete
 
         #region ctor
 
-        public RedisAutocompleteManager():this("DefaultRedisAutocomplete")
+        public RedisAutocompleteManager(): this(ConfigurationManager.ConnectionStrings["DefaultRedisAutocomplete"].ConnectionString)
         {
-            
         }
 
         public RedisAutocompleteManager(string redisConnectionString) 
@@ -34,8 +33,7 @@ namespace RedisAutocomplete
 
             try
             {
-                
-                   var _redis = ConnectionMultiplexer.Connect(ConfigurationManager.ConnectionStrings[redisConnectionString].ConnectionString );
+                var _redis = ConnectionMultiplexer.Connect(redisConnectionString);
                 
                 _db = _redis.GetDatabase();
             }


### PR DESCRIPTION
I pull out hardcoded `ConfigurationManager` dependency and give a room to accept raw connection string. 
This is useful when it is deployed in Azure, as Azure uses `CloudConfigurationManager` instead.
